### PR TITLE
Update atomic slasher fees to be stored in RenExBalances

### DIFF
--- a/migrations/1_deploy_republic_contracts.js
+++ b/migrations/1_deploy_republic_contracts.js
@@ -1,5 +1,3 @@
-const BigNumber = require("bignumber.js");
-
 const RepublicToken = artifacts.require("RepublicToken");
 const DarknodeRegistryStore = artifacts.require("DarknodeRegistryStore");
 const DarknodeRegistry = artifacts.require("DarknodeRegistry");

--- a/migrations/1_deploy_republic_contracts.js
+++ b/migrations/1_deploy_republic_contracts.js
@@ -22,7 +22,7 @@ module.exports = async function (deployer, network) {
             DarknodeRegistry,
             RepublicToken.address,
             DarknodeRegistryStore.address,
-            new BigNumber(config.MINIMUM_BOND),
+            config.MINIMUM_BOND,
             config.MINIMUM_POD_SIZE,
             config.MINIMUM_EPOCH_INTERVAL
         ))

--- a/migrations/config.js
+++ b/migrations/config.js
@@ -3,7 +3,7 @@ const BN = require("bn.js");
 const GWEI = 1000000000;
 
 module.exports = {
-    MINIMUM_BOND: new BN(100000).pow(new BN(1).pow(new BN(18))),
+    MINIMUM_BOND: new BN(100000).mul(new BN(10).pow(new BN(18))),
     INGRESS_FEE: 10,
     MINIMUM_POD_SIZE: 3, // 24 in production
     MINIMUM_EPOCH_INTERVAL: 2, // 14400 in production

--- a/test-ts/AtomicBondSlashing.ts
+++ b/test-ts/AtomicBondSlashing.ts
@@ -6,7 +6,6 @@ import { BN } from "bn.js";
 
 import { RenExBalancesContract } from "./bindings/ren_ex_balances";
 import { RenExSettlementContract } from "./bindings/ren_ex_settlement";
-import { DarknodeRewardVaultContract } from "./bindings/darknode_reward_vault";
 import { RenExTokensContract } from "./bindings/ren_ex_tokens";
 import { OrderbookContract } from "./bindings/orderbook";
 import { DarknodeRegistryContract } from "./bindings/darknode_registry";
@@ -21,7 +20,6 @@ contract("Slasher", function (accounts: string[]) {
 
     let dnr: DarknodeRegistryContract;
     let orderbook: OrderbookContract;
-    let darknodeRewardVault: DarknodeRewardVaultContract;
     let renExSettlement: RenExSettlementContract;
     let renExBalances: RenExBalancesContract;
     let renExTokens: RenExTokensContract;
@@ -41,7 +39,6 @@ contract("Slasher", function (accounts: string[]) {
 
         dnr = await artifacts.require("DarknodeRegistry").deployed();
         orderbook = await artifacts.require("Orderbook").deployed();
-        darknodeRewardVault = await artifacts.require("DarknodeRewardVault").deployed();
         renExSettlement = await artifacts.require("RenExSettlement").deployed();
         renExBalances = await artifacts.require("RenExBalances").deployed();
         // Register extra token
@@ -87,7 +84,7 @@ contract("Slasher", function (accounts: string[]) {
         let fees = new BN(web3.utils.toWei(feeNum, "ether")).div(feeDen);
 
         // Store the original balances
-        let beforeBurntBalance = new BN(await darknodeRewardVault.darknodeBalances(slasher, eth_address));
+        let beforeBurntBalance = new BN(await renExBalances.traderBalances(slasher, eth_address));
         let beforeGuiltyBalance = new BN(await renExBalances.traderBalances(guiltyAddress, eth_address));
         let beforeInnocentBalance = new BN(await renExBalances.traderBalances(innocentAddress, eth_address));
 
@@ -95,7 +92,7 @@ contract("Slasher", function (accounts: string[]) {
         await renExSettlement.slash(guiltyOrderID, { from: slasher });
 
         // Check the new balances
-        let afterBurntBalance = new BN(await darknodeRewardVault.darknodeBalances(slasher, eth_address));
+        let afterBurntBalance = new BN(await renExBalances.traderBalances(slasher, eth_address));
         let afterGuiltyBalance = new BN(await renExBalances.traderBalances(guiltyAddress, eth_address));
         let afterInnocentBalance = new BN(await renExBalances.traderBalances(innocentAddress, eth_address));
 

--- a/test-ts/RenExBalances.ts
+++ b/test-ts/RenExBalances.ts
@@ -78,6 +78,10 @@ contract("RenExBalances", function (accounts: string[]) {
         // Check that the tokens have been returned
         (await TOKEN1.balanceOf(accounts[0])).should.bignumber.equal(previous1);
         (await TOKEN2.balanceOf(accounts[0])).should.bignumber.equal(previous2);
+
+        // Check that balance in renExBalances is zeroed
+        (await renExBalances.traderBalances(accounts[0], TOKEN1.address)).should.bignumber.equal(0);
+        (await renExBalances.traderBalances(accounts[0], TOKEN2.address)).should.bignumber.equal(0);
     });
 
     it("can hold tokens for multiple traders", async () => {


### PR DESCRIPTION
Previously, the atomic slasher's fees where transferred to the `DarknodeRewardVault` contract.

This is problematic because:

1) The fees couldn't be withdrawn without the Atomic Slasher being registered as a darknode and
2) Is not the intended purpose of the reward vault contract.

The fees are now stored in the `RenExBalanances` contract.